### PR TITLE
fix: pnpm install fails in CI after the update script edits package.json

### DIFF
--- a/.github/scripts/deps-check-and-update.mjs
+++ b/.github/scripts/deps-check-and-update.mjs
@@ -139,7 +139,9 @@ function ageCutoff() {
 
 // Returns the name of the first failing stage, or null if everything passed.
 function installAndTest() {
-    if (!tryRun('pnpm install')) return 'install';
+    // --no-frozen-lockfile: pnpm defaults frozen-lockfile to true on CI, but
+    // this script has just changed package.json on purpose.
+    if (!tryRun('pnpm install --no-frozen-lockfile')) return 'install';
     if (!tryRun('pnpm run build')) return 'build';
     if (!tryRun('pnpm exec playwright test')) return 'e2e';
     return null;
@@ -193,7 +195,8 @@ function finalize(prevVersion, applied, failedGroups) {
     pkg.version = nextVersion;
     writePkg(pkg);
     // Sync the version field into the lockfile without touching node_modules.
-    run('pnpm install --lockfile-only');
+    // --no-frozen-lockfile: see installAndTest().
+    run('pnpm install --lockfile-only --no-frozen-lockfile');
 
     updateReadmeVersions(pkg);
     writePrBody(applied, prevVersion, nextVersion, failedGroups);


### PR DESCRIPTION
## 問題

初回の dry_run（run 28644703066）で、3グループすべてが install 段階で失敗しました。

原因: **pnpm は CI 環境では `frozen-lockfile` がデフォルトで true** になるため、deps-check-and-update.mjs が package.json を書き換えた直後の素の `pnpm install` が `ERR_PNPM_OUTDATED_LOCKFILE` で拒否されます。ローカル検証では CI 環境変数が無いため再現しませんでした。

## 修正

スクリプトは意図的に package.json を変更するので、`--no-frozen-lockfile` を明示:
- `installAndTest()` の `pnpm install`
- `finalize()` の `pnpm install --lockfile-only`（防御的に付与）

ワークフロー側の `pnpm install --frozen-lockfile`（ベースライン構築・ロールバック）は正しい挙動のため変更なし。

## 検証

- ローカルで `CI=true` を付けて CI と同一のエラーを再現 → 修正版コマンドで成功を確認
- なお dry_run では失敗検知系は設計どおり動作していました（グループごとのロールバック → Slack 通知 → run を fail）

マージ後、workflow_dispatch（dry_run=true）を再実行して全経路を確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)