### PR TITLE
embed visual comparison in deps PRs, fourth-segment version rule

### DIFF
--- a/.github/scripts/deps-check-and-update.mjs
+++ b/.github/scripts/deps-check-and-update.mjs
@@ -7,6 +7,11 @@
 // the PR body plus GitHub Actions step outputs (changed / delta /
 // prev_version / next_version / updated_packages / failed_groups).
 //
+// Project version rule: a Leaflet update adopts the Leaflet version itself
+// (1.9.4 -> 1.9.5); any other update increments a fourth segment on top of
+// the current version (1.9.4 -> 1.9.4.1 -> 1.9.4.2). The fourth segment is
+// not semver — fine for git tags and this unpublished package.
+//
 // Run locally: first create the visual baselines the e2e gate diffs against
 // (pnpm exec playwright test e2e/visual.spec.ts --update-snapshots), then
 // node .github/scripts/deps-check-and-update.mjs
@@ -182,13 +187,14 @@ function finalize(prevVersion, applied, failedGroups) {
         return;
     }
 
-    // Adopt the Leaflet version when Leaflet changed, otherwise bump the patch.
-    // Never move backward (a Leaflet patch release arriving after unrelated
-    // bumps must not collide with an existing tag).
+    // Adopt the Leaflet version when Leaflet changed, otherwise increment the
+    // fourth segment (see the header). Never move backward (a Leaflet patch
+    // release arriving after unrelated bumps must not collide with an
+    // existing tag).
     const leafletUpdate = applied.find((u) => u.name === 'leaflet');
-    let nextVersion = leafletUpdate ? leafletUpdate.to : bumpPatch(prevVersion);
-    if (compareVersions(nextVersion, prevVersion) <= 0) {
-        nextVersion = bumpPatch(prevVersion);
+    let nextVersion = leafletUpdate ? leafletUpdate.to : bumpFourth(prevVersion);
+    if (compareProjectVersions(nextVersion, prevVersion) <= 0) {
+        nextVersion = bumpFourth(prevVersion);
     }
 
     const pkg = readPkg();
@@ -240,6 +246,24 @@ function writePrBody(applied, prevVersion, nextVersion, failedGroups) {
         '- build (tsc + vite): OK',
         '- e2e smoke + visual diff vs pre-update main + runtime error check: OK',
     ];
+    // Both images live in this repo (no external hosting). The "after" link
+    // dies when the bot branch is deleted on merge — at which point main's
+    // image IS the after state. Keep the branch name in sync with the
+    // Create Pull Request step in deps-autoupdate.yml.
+    if (process.env.GITHUB_REPOSITORY) {
+        const raw = `https://raw.githubusercontent.com/${process.env.GITHUB_REPOSITORY}`;
+        const image = 'e2e/screenshots/map.png';
+        lines.push(
+            '',
+            '## Visual comparison (should look identical)',
+            '',
+            '| Before (main) | After (deps updated) |',
+            '| --- | --- |',
+            `| ![before](${raw}/main/${image}) | ![after](${raw}/bot/deps-update/${image}) |`,
+            '',
+            `If rendering changed, \`${image}\` also appears under Files changed with GitHub's image diff viewers (missing there = pixel-identical).`
+        );
+    }
     if (failedGroups.length > 0) {
         lines.push(
             '',
@@ -307,9 +331,28 @@ function compareVersions(a, b) {
     return 0;
 }
 
-function bumpPatch(version) {
-    const [major, minor, patch] = parseStable(version);
-    return `${major}.${minor}.${patch + 1}`;
+// The PROJECT version allows an optional fourth segment ("1.9.4" or
+// "1.9.4.1"); registry versions stay strict three-segment (parseStable) on
+// purpose. Returns [major, minor, patch, fourth].
+function parseProjectVersion(version) {
+    const m = String(version).match(/^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?$/);
+    if (!m) throw new Error(`Invalid project version: ${version}`);
+    return [Number(m[1]), Number(m[2]), Number(m[3]), m[4] === undefined ? 0 : Number(m[4])];
+}
+
+function compareProjectVersions(a, b) {
+    const pa = parseProjectVersion(a);
+    const pb = parseProjectVersion(b);
+    for (let i = 0; i < 4; i++) {
+        if (pa[i] !== pb[i]) return pa[i] - pb[i];
+    }
+    return 0;
+}
+
+// "1.9.4" -> "1.9.4.1", "1.9.4.1" -> "1.9.4.2"
+function bumpFourth(version) {
+    const [major, minor, patch, fourth] = parseProjectVersion(version);
+    return `${major}.${minor}.${patch}.${fourth + 1}`;
 }
 
 function writeGithubOutput(keyValues) {

--- a/.github/workflows/deps-autoupdate.yml
+++ b/.github/workflows/deps-autoupdate.yml
@@ -80,6 +80,18 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: node .github/scripts/deps-check-and-update.mjs
 
+      # Human-facing canonical screenshot committed with the PR. Byte-identical
+      # render -> no diff entry (pixel-identical, nothing to review); when the
+      # render did change, GitHub's image diff viewers (2-up / swipe / onion
+      # skin) apply. The PR body also embeds before/after raw URLs of this
+      # file (see writePrBody in deps-check-and-update.mjs).
+      - name: Refresh canonical screenshot
+        if: steps.update.outputs.changed == 'true'
+        run: |
+          pnpm exec playwright test e2e/visual.spec.ts --update-snapshots
+          mkdir -p e2e/screenshots
+          cp .playwright-snapshots/visual.spec.ts-snapshots/map-*.png e2e/screenshots/map.png
+
       - name: Create Pull Request
         id: cpr
         if: steps.update.outputs.changed == 'true' && inputs.dry_run != true
@@ -102,6 +114,7 @@ jobs:
             package.json
             pnpm-lock.yaml
             README.md
+            e2e/screenshots/map.png
 
       - name: Upload artifacts
         if: ${{ always() && (failure() || steps.update.outputs.changed == 'true' || steps.update.outputs.failed_groups != '') }}
@@ -115,6 +128,9 @@ jobs:
             .playwright-snapshots/
           if-no-files-found: ignore
           retention-days: 14
+          # Without this, dot-directories like .playwright-snapshots are
+          # silently dropped from the artifact (upload-artifact v4 default).
+          include-hidden-files: true
 
       # Message logic (including the 10-day heartbeat) lives in
       # .github/scripts/notify-slack.sh; this step only maps step results

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ The visual test compares against a local baseline that is intentionally not comm
 
 - `dist/` — local build output (gitignored)
 - `img/` — images used by this README
+- `e2e/screenshots/map.png` — canonical map render, overwritten by the deps workflow; it shows up in a PR's Files changed only when rendering actually changed (absent = pixel-identical)
 - CI (`.github/workflows/ci.yml`) builds and runs the Playwright smoke test on every PR and push to main
 - GitHub Pages (`.github/workflows/pages.yml`) rebuilds the demo from source and redeploys it on every push to main — no build output is committed
-- A daily workflow (`.github/workflows/deps-autoupdate.yml`) bumps leaflet/typescript/vite behind build + e2e gates and opens a PR; merging it tags and publishes a GitHub Release automatically. The package version follows the bundled Leaflet version (hence `1.9.4`).
+- A daily workflow (`.github/workflows/deps-autoupdate.yml`) bumps leaflet/typescript/vite behind build + e2e gates and opens a PR; merging it tags and publishes a GitHub Release automatically. The package version follows the bundled Leaflet version (hence `1.9.4`); non-Leaflet updates increment a fourth segment instead (e.g. `1.9.4.1`).
 
 <br>
 
@@ -143,9 +144,10 @@ pnpm test
 
 - `dist/` — ローカルビルド出力（gitignore 対象）
 - `img/` — この README 用の画像
+- `e2e/screenshots/map.png` — 地図描画の正典スクリーンショット。依存更新ワークフローが毎回上書きし、描画が実際に変わったときだけ PR の Files changed に現れます（現れない = ピクセル一致）
 - CI（`.github/workflows/ci.yml`）が PR と main への push ごとにビルドと Playwright スモークテストを実行
 - GitHub Pages（`.github/workflows/pages.yml`）が main への push ごとにソースからデモを再ビルドして再デプロイ — ビルド成果物はコミットしません
-- 日次ワークフロー（`.github/workflows/deps-autoupdate.yml`）が leaflet/typescript/vite をビルド + e2e のゲート付きで更新し PR を作成。マージすると自動でタグ付けと GitHub Release が行われます。パッケージのバージョンは同梱の Leaflet バージョンに追従します（そのため `1.9.4`）。
+- 日次ワークフロー（`.github/workflows/deps-autoupdate.yml`）が leaflet/typescript/vite をビルド + e2e のゲート付きで更新し PR を作成。マージすると自動でタグ付けと GitHub Release が行われます。パッケージのバージョンは同梱の Leaflet バージョンに追従し（そのため `1.9.4`）、Leaflet 以外のみの更新では4桁目を増分します（例: `1.9.4.1`）。
 
 <br>
 


### PR DESCRIPTION
- Overwrite a canonical screenshot (e2e/screenshots/map.png) in each deps PR: byte-identical when rendering is unchanged, GitHub image diff when not
- Embed before/after raw URLs of the canonical screenshot in the PR body
- Non-Leaflet updates now increment a fourth version segment (1.9.4.1 -> 1.9.4.2); Leaflet updates adopt the Leaflet version and reset it
- Fix Upload artifacts silently dropping .playwright-snapshots (upload-artifact v4 excludes hidden files by default)